### PR TITLE
feat: create CLI outline skeleton with src, commands, docs

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+const { program } = require('commander');
+
+program
+  .command('compile <circomFilePath>')
+  .description('Compile a circom circuit')
+  .action((circomFilePath) => {
+    // Call compile function here
+  });
+
+
+program.parse(process.argv);

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -1,0 +1,16 @@
+# zkArb SDK – Daily Dev Log
+
+## Oct 6, 2025
+**Branch:** feat/cli-outline
+
+**Tasks Completed:**
+- Initialized CLI folder structure:
+  - `bin/cli.js` as entry point
+  - `lib/` folder for future commands
+- Created `docs/DEVLOG.md` to track work
+- Added initial `README.md` with project overview
+- Created `examples/` folder for sample circuits
+
+**Notes / Next Steps:**
+- Plan first functional command (compile command)
+- Integrate initial placeholder commands in `commands/` folder

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,67 @@
+{
+  "name": "zkarb-sdk",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zkarb-sdk",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "^14.0.1",
+        "fs-extra": "^11.3.2"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.1.tgz",
+      "integrity": "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
+      "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "zkarb-sdk",
+  "version": "1.0.0",
+  "description": "Zero-knowledge SDK for Circom → Solidity → Arbitrum verifier deployment and proof verification.",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs",
+    "example": "examples"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jatinsahijwani/zkArb-sdk.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/jatinsahijwani/zkArb-sdk/issues"
+  },
+  "homepage": "https://github.com/jatinsahijwani/zkArb-sdk#readme",
+  "dependencies": {
+    "commander": "^14.0.1",
+    "fs-extra": "^11.3.2"
+  }
+}


### PR DESCRIPTION
Added initial CLI skeleton for zkArb-sdk:

- bin/cli.js → CLI entry point
- lib/ folder → placeholder commands
- docs/DEVLOG.md → daily dev log

Next: implement CLI command registration and first functional command.
